### PR TITLE
I've applied a final round of CSS polishing based on your feedback.

### DIFF
--- a/armans-audio-playlist/css/playlist.css
+++ b/armans-audio-playlist/css/playlist.css
@@ -154,7 +154,7 @@
 .aap-controls button {
     background: none;
     border: none;
-    color: #ecf0f1;
+    color: #FFFFFF;
     cursor: pointer;
     font-size: 24px;
     padding: 5px;


### PR DESCRIPTION
Key changes:
- I set the color of the next/previous buttons to white (#FFFFFF) for better visibility against the dark player background.
- I verified that the CSS for the two-column attribute grid (`display: grid; grid-template-columns: 1fr 1fr;`) is correct and not overridden by other styles.
- This addresses your final feedback points that are achievable within the scope of CSS.