### PR TITLE
This commit is my final attempt to resolve the persistent styling iss…

### DIFF
--- a/armans-audio-playlist/includes/scripts.php
+++ b/armans-audio-playlist/includes/scripts.php
@@ -2,15 +2,8 @@
 
 // Enqueue scripts and styles for the frontend
 function aap_enqueue_scripts() {
-    // Enqueue the stylesheet with cache-busting.
-    $css_file_path = AAP_PLUGIN_PATH . 'css/playlist.css';
-    $css_version = file_exists($css_file_path) ? filemtime($css_file_path) : '1.0';
-    wp_enqueue_style(
-        'aap-playlist-style',
-        AAP_PLUGIN_URL . 'css/playlist.css',
-        array(),
-        $css_version
-    );
+    // The cache-busting via filemtime didn't work for the user, so we will now print styles inline.
+    // The wp_enqueue_style call has been removed.
 
     // Enqueue the JavaScript with cache-busting.
     $js_file_path = AAP_PLUGIN_PATH . 'js/playlist.js';
@@ -30,6 +23,17 @@ function aap_enqueue_scripts() {
     ) );
 }
 add_action( 'wp_enqueue_scripts', 'aap_enqueue_scripts' );
+
+// Print styles inline to avoid caching issues.
+function aap_print_inline_styles() {
+    $css_file_path = AAP_PLUGIN_PATH . 'css/playlist.css';
+    if ( file_exists( $css_file_path ) ) {
+        echo '<style type="text/css">';
+        readfile( $css_file_path );
+        echo '</style>';
+    }
+}
+add_action( 'wp_head', 'aap_print_inline_styles' );
 
 
 // Helper function to get all unique attribute values across all playlists

--- a/armans-audio-playlist/js/playlist.js
+++ b/armans-audio-playlist/js/playlist.js
@@ -64,6 +64,17 @@ jQuery(document).ready(function($) {
             });
             // Update trackElements to only include visible tracks for next/prev functionality
             trackElements = container.find('.aap-track-icon:visible');
+
+            // Auto-play the first visible track, if any
+            if (trackElements.length > 0) {
+                // Use .first() to get the jQuery object of the first element and trigger a click
+                trackElements.first().trigger('click');
+            } else {
+                // If no tracks match, pause the player and reset info
+                pauseTrack();
+                trackTitleEl.text('No matching tracks');
+                trackAttributesEl.html('');
+            }
         });
 
 


### PR DESCRIPTION
…ues and implement a new feature.

Key changes:
- I've replaced the `wp_enqueue_style` for `playlist.css` with a function that prints the CSS contents directly into the HTML head. This is a robust method to bypass any potential caching issues in your environment.
- I've added an auto-play feature: when you select a filter, the first available track in the filtered list will automatically be selected and played.
- This commit includes all previous styling changes for buttons, layouts, and colors.